### PR TITLE
feat: 新增使用节奏追踪功能

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "antigravity-quota-watcher",
-  "version": "0.7.4",
+  "version": "0.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "antigravity-quota-watcher",
-      "version": "0.7.4",
+      "version": "0.7.6",
       "license": "MIT",
       "dependencies": {
         "https": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -116,6 +116,35 @@
           ],
           "description": "%config.language%",
           "order": 80
+        },
+        "antigravityQuotaWatcher.quotaCycleDuration": {
+          "type": "number",
+          "default": 300,
+          "minimum": 1,
+          "description": "%config.quotaCycleDuration%",
+          "order": 90
+        },
+        "antigravityQuotaWatcher.showUsagePaceTracking": {
+          "type": "boolean",
+          "default": true,
+          "description": "%config.showUsagePaceTracking%",
+          "order": 91
+        },
+        "antigravityQuotaWatcher.usagePaceWarningGap": {
+          "type": "number",
+          "default": 10,
+          "minimum": 1,
+          "maximum": 100,
+          "description": "%config.usagePaceWarningGap%",
+          "order": 92
+        },
+        "antigravityQuotaWatcher.usagePaceCriticalGap": {
+          "type": "number",
+          "default": 30,
+          "minimum": 1,
+          "maximum": 100,
+          "description": "%config.usagePaceCriticalGap%",
+          "order": 93
         }
       }
     }

--- a/package.nls.json
+++ b/package.nls.json
@@ -11,5 +11,9 @@
     "config.showPlanName": "Show plan name in status bar (not officially enabled yet)",
     "config.showPromptCredits": "Show Prompt Credits (not officially enabled yet)",
     "config.forcePowerShell": "Use PowerShell mode for process detection [Windows only, requires extension restart]",
-    "config.language": "Language / 语言"
+    "config.language": "Language / 语言",
+    "config.quotaCycleDuration": "Quota reset cycle duration in minutes (default: 300 = 5 hours)",
+    "config.showUsagePaceTracking": "Show usage pace tracking (compare actual vs ideal consumption rate)",
+    "config.usagePaceWarningGap": "Usage pace warning threshold: alert when behind by this percentage",
+    "config.usagePaceCriticalGap": "Usage pace critical threshold: urgent alert when behind by this percentage"
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -11,5 +11,9 @@
     "config.showPlanName": "在状态栏显示套餐级别（官方暂未启用此字段）",
     "config.showPromptCredits": "显示 Prompt Credits（官方暂未启用此字段）",
     "config.forcePowerShell": "使用 PowerShell 模式检测进程【仅 Windows 系统可用，插件重启生效】",
-    "config.language": "Language / 语言"
+    "config.language": "Language / 语言",
+    "config.quotaCycleDuration": "配额重置周期时长（分钟，默认 300 = 5 小时）",
+    "config.showUsagePaceTracking": "显示使用节奏追踪（对比实际消费进度与理想进度）",
+    "config.usagePaceWarningGap": "使用节奏警告阈值：落后此百分比时提醒",
+    "config.usagePaceCriticalGap": "使用节奏严重警告阈值：落后此百分比时紧急提醒"
 }

--- a/src/configService.ts
+++ b/src/configService.ts
@@ -22,7 +22,12 @@ export class ConfigService {
       showPromptCredits: config.get<boolean>('showPromptCredits', false),
       showPlanName: config.get<boolean>('showPlanName', false),
       displayStyle: (config.get<string>('displayStyle', 'progressBar') as Config['displayStyle']),
-      language: (config.get<string>('language', 'auto') as Config['language'])
+      language: (config.get<string>('language', 'auto') as Config['language']),
+      // Usage Pace tracking configuration
+      quotaCycleDuration: config.get<number>('quotaCycleDuration', 300),
+      showUsagePaceTracking: config.get<boolean>('showUsagePaceTracking', true),
+      usagePaceWarningGap: config.get<number>('usagePaceWarningGap', 10),
+      usagePaceCriticalGap: config.get<number>('usagePaceCriticalGap', 30)
     };
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,7 +40,8 @@ export async function activate(context: vscode.ExtensionContext) {
     config.criticalThreshold,
     config.showPromptCredits,
     config.showPlanName,
-    config.displayStyle
+    config.displayStyle,
+    config.showUsagePaceTracking
   );
   // 显示检测状态
   statusBarService.showDetecting();
@@ -95,6 +96,12 @@ export async function activate(context: vscode.ExtensionContext) {
     quotaService.setApiMethod(config.apiMethod === 'COMMAND_MODEL_CONFIG'
       ? QuotaApiMethod.COMMAND_MODEL_CONFIG
       : QuotaApiMethod.GET_USER_STATUS);
+    // Set usage pace tracking config
+    quotaService.setUsagePaceConfig(
+      config.quotaCycleDuration,
+      config.usagePaceWarningGap,
+      config.usagePaceCriticalGap
+    );
 
     // Register quota update callback
     quotaService.onQuotaUpdate((snapshot: QuotaSnapshot) => {
@@ -324,6 +331,13 @@ function handleConfigChange(config: Config): void {
     statusBarService?.setShowPromptCredits(config.showPromptCredits);
     statusBarService?.setShowPlanName(config.showPlanName);
     statusBarService?.setDisplayStyle(config.displayStyle);
+    statusBarService?.setShowUsagePaceTracking(config.showUsagePaceTracking);
+    // Update usage pace config in quota service
+    quotaService?.setUsagePaceConfig(
+      config.quotaCycleDuration,
+      config.usagePaceWarningGap,
+      config.usagePaceCriticalGap
+    );
 
     // Update language
     const localizationService = LocalizationService.getInstance();

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -24,6 +24,13 @@ export const en: TranslationMap = {
     'tooltip.clickToRetry': 'Click to retry',
     'tooltip.clickToRecheck': 'Click to recheck login status',
 
+    // Usage Pace tracking
+    'tooltip.usagePace': 'Usage Pace',
+    'usagePace.ahead': '✅Ahead',
+    'usagePace.onTrack': '✅OK',
+    'usagePace.behind': '⚠️Behind',
+    'usagePace.critical': '🚨Falling behind!',
+
     // Messages
     'msg.portDetectionFailed': 'Antigravity Quota Watcher: Failed to detect port. Please ensure Antigravity is running.',
     'msg.portDetectionSuccess': 'Antigravity Quota Watcher: Port detected successfully.',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -21,6 +21,13 @@ export type TranslationKey =
     | 'tooltip.notLoggedIn'
     | 'tooltip.clickToRetry'
     | 'tooltip.clickToRecheck'
+    | 'tooltip.usagePace'
+
+    // Usage Pace tracking
+    | 'usagePace.ahead'
+    | 'usagePace.onTrack'
+    | 'usagePace.behind'
+    | 'usagePace.critical'
 
     // Messages
     | 'msg.portDetectionFailed'

--- a/src/i18n/zh-cn.ts
+++ b/src/i18n/zh-cn.ts
@@ -24,6 +24,13 @@ export const zh_cn: TranslationMap = {
     'tooltip.clickToRetry': '点击重试',
     'tooltip.clickToRecheck': '点击重新检查登录状态',
 
+    // 使用节奏追踪
+    'tooltip.usagePace': '使用节奏',
+    'usagePace.ahead': '✅超前',
+    'usagePace.onTrack': '✅正常',
+    'usagePace.behind': '⚠️落后',
+    'usagePace.critical': '🚨严重落后!',
+
     // 消息
     'msg.portDetectionFailed': 'Antigravity Quota Watcher: 端口检测失败。请确保 Antigravity 正在运行。',
     'msg.portDetectionSuccess': 'Antigravity Quota Watcher: 端口检测成功。',

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,8 @@ export interface PromptCreditsInfo {
   remainingPercentage: number;
 }
 
+export type PaceStatus = 'ahead' | 'onTrack' | 'behind' | 'critical';
+
 export interface ModelQuotaInfo {
   label: string;
   modelId: string;
@@ -52,6 +54,11 @@ export interface ModelQuotaInfo {
   resetTime: Date;
   timeUntilReset: number;
   timeUntilResetFormatted: string;
+  // Usage Pace tracking fields
+  usedPercentage?: number;           // (1 - remainingFraction) * 100
+  idealUsedPercentage?: number;      // Expected usage based on time elapsed
+  usagePaceGap?: number;             // idealUsed - actualUsed (positive = behind)
+  paceStatus?: PaceStatus;           // Usage pace indicator
 }
 
 export interface QuotaSnapshot {
@@ -80,4 +87,9 @@ export interface Config {
   showPlanName: boolean;
   displayStyle: 'percentage' | 'progressBar' | 'dots';
   language: 'auto' | 'en' | 'zh-cn';
+  // Usage Pace tracking configuration
+  quotaCycleDuration: number;         // Quota cycle duration in minutes (default 300 = 5 hours)
+  showUsagePaceTracking: boolean;     // Whether to show usage pace tracking
+  usagePaceWarningGap: number;        // Warning threshold (behind percentage), default 10
+  usagePaceCriticalGap: number;       // Critical threshold (behind percentage), default 30
 }


### PR DESCRIPTION
## 💡 背景

在使用插件的过程中发现一个痛点：Antigravity 的配额是 5 小时重置一次，但我经常在周期快结束时还剩大量配额没用完，白白浪费了。

于是萌生了一个想法：**能不能实时看到当前的「使用节奏」是超前还是落后？** 这样就能更合理地安排使用，把配额用满。

## 🎯 功能说明

新增「使用节奏追踪」功能，通过对比「理想消费进度」与「实际消费进度」，直观展示当前配额使用是否跟上时间节奏。

**核心逻辑**：
- 理想进度 = 周期已过时间 ÷ 周期总时长 × 100%
- 节奏差距 = 理想进度 − 实际消费进度
- 正值 = 落后（需加快使用），负值 = 超前（使用充分）

## ✨ 具体表现

- **状态栏**：在配额旁显示节奏指示，如 `⬆️+15%`（超前）或 `⬇️-12%`（落后）
- **Tooltip**：表格新增「使用节奏」列，显示状态文字 + 百分比

## ⚙️ 新增配置项

| 配置项 | 默认值 | 说明 |
|--------|--------|------|
| `quotaCycleDuration` | 300 | 周期时长（分钟） |
| `showUsagePaceTracking` | true | 功能开关 |
| `usagePaceWarningGap` | 10 | 落后多少%时警告 |
| `usagePaceCriticalGap` | 30 | 落后多少%时严重警告 |

## 📝 主要改动

- `types.ts`：新增 `PaceStatus` 类型和 `usagePaceGap` 字段
- `quotaService.ts`：计算使用节奏
- `statusBar.ts`：状态栏和 Tooltip 展示逻辑
- `extension.ts`：配置传递
- `i18n/*.ts`：中英文本地化支持

---

代码已做精简优化，欢迎评审！如有任何问题或建议，随时沟通 🙏