### PR TITLE
feat: add full English translation (closes #48)

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,97 +1,96 @@
-# ⚙️ 配置选项
+# ⚙️ Configuration Options
 
-打开 VS Code 设置（`文件` > `首选项` > `设置`），搜索 `Antigravity Quota Watcher`：
+Open VS Code settings (`File` > `Preferences` > `Settings`), and search for `Antigravity Quota Watcher`:
 
-## 启用自动监控
-- **默认值**：`true`
-- **说明**：是否启用配额监控
+## Enable Auto Monitoring
+- **Default**: `true`
+- **Description**: Whether to enable quota monitoring
 
-## 轮询间隔
-- **默认值**：`60`（秒）
-- **说明**：配额数据刷新频率，建议设置为 30-60 秒
+## Polling Interval
+- **Default**: `60` (seconds)
+- **Description**: Quota data refresh frequency, recommended to set between 30-60 seconds
 
-## 警告阈值
-- **默认值**：`50`（百分比）
-- **说明**：配额低于此百分比时状态栏显示黄色警告符号（🟡）
+## Warning Threshold
+- **Default**: `50` (percentage)
+- **Description**: When quota falls below this percentage, the status bar displays a yellow warning symbol (🟡)
 
-## 临界阈值
-- **默认值**：`30`（百分比）
-- **说明**：配额低于此百分比时状态栏显示红色错误符号（🔴）
+## Critical Threshold
+- **Default**: `30` (percentage)
+- **Description**: When quota falls below this percentage, the status bar displays a red error symbol (🔴)
 
-## 状态栏显示样式
-- **默认值**：`progressBar`
-- **选项**：
-  - `progressBar`：显示进度条（ `████░░░░`）
-  - `percentage`：显示百分比（ `80%`）
-  - `dots`：显示圆点（ `●●●○○`）
-- **说明**：选择状态栏的显示风格
+## Status Bar Display Style
+- **Default**: `progressBar`
+- **Options**:
+  - `progressBar`: Display progress bar (`████░░░░`)
+  - `percentage`: Display percentage (`80%`)
+  - `dots`: Display dots (`●●●○○`)
+- **Description**: Choose the status bar display style
 
-## API 方法选择
-- **默认值**：`GOOGLE_API`
-- **选项**：
-  - `GOOGLE_API`：远程模式 - 直接调用 Google Cloud Code API 获取配额，数据基本是最新的，响应快速
-  - `GET_USER_STATUS`：本地模式 - 通过本地 Antigravity 语言服务器获取配额，存在较大延迟（因为依赖 LSP）
-- **说明**：选择配额获取方式
+## API Method Selection
+- **Default**: `GET_USER_STATUS`
+- **Options**:
+  - `GOOGLE_API`: Remote mode - Directly calls Google Cloud Code API to fetch quota, data is almost real-time with fast response
+  - `GET_USER_STATUS`: Local mode - Fetches quota through local Antigravity language server, has significant delay (depends on LSP)
+- **Description**: Choose the quota fetching method
 
-
-### Google API 方式使用说明
+### Google API Usage Instructions
 
 > [!WARNING]
-> **安全提醒**：`GOOGLE_API` 方法需要登录您的 Google 账号以获取 `access token` 和 `refresh token`。这些 token 属于**敏感凭证信息**，若泄露，他人可通过您的 `refresh token` 使用您账号的 AI 额度。
+> **Security Notice**: The `GOOGLE_API` method requires logging into your Google account to obtain `access token` and `refresh token`. These tokens are **sensitive credentials** - if leaked, anyone can use your `refresh token` to consume your account's AI quota.
 >
-> **本项目承诺**：本项目完全开源免费，**绝不保存或上传任何用户 token**，所有凭证仅存储在您本地设备中。
+> **Our Commitment**: This project is completely open-source and free. We **never store or upload any user tokens** - all credentials are stored only on your local device.
 >
-> **风险警示**：目前基于本项目的 fork 版本较多，请大家注意甄别风险。在安装任何配额插件前，建议先借助 AI 工具审查其代码，确认是否安全、是否存在后门。
+> **Risk Warning**: There are currently many fork versions based on this project. Please be vigilant about potential risks. Before installing any quota watching plugins, we recommend using AI tools to review its code to ensure it is safe and free of backdoors.
 
-如果选择 `GOOGLE_API` 方法，需要使用 Google 账号登录：
+If you choose the `GOOGLE_API` method, you need to login with your Google account:
 
-**登录方式**：
-1. 点击右下角插件状态栏提示语
-2. 在浏览器中完成 Google 账号授权
-3. 授权成功后插件会自动开始获取配额
+**Login Method**:
+1. Click the bottom-right extension status bar prompt
+2. Complete Google account authorization in the browser
+3. After successful authorization, the extension will automatically start fetching quota
 
-**登出方式**：
-1. 打开命令面板（`Ctrl+Shift+P` 或 `Cmd+Shift+P`）
-2. 输入并执行 `Antigravity Quota Watcher: Google Logout`
+**Logout Method**:
+1. Open command palette (`Ctrl+Shift+P` or `Cmd+Shift+P`)
+2. Type and execute `Antigravity Quota Watcher: Google Logout`
 
-### 自动检测本地 Token
+### Auto-detect Local Token
 
-如果您已经在 Antigravity IDE 中登录了 Google 账号，插件会自动检测本地的登录凭证：
+If you have already logged into your Google account in the Antigravity IDE, the plugin will automatically detect local login credentials:
 
-1. **未登录状态**：插件会检测本地 Antigravity 是否已登录，如果检测到有效的登录凭证，会弹窗询问是否直接使用本地账号登录
-2. **已登录状态（使用本地 Token）**：如果您的账号是通过本地 Token 导入的，插件会定期检查本地 Antigravity 的登录状态变化：
-   - 如果本地切换了账号，会弹窗询问是否同步新账号
-   - 如果本地退出了登录，会弹窗询问是否同步退出
+1. **Not Logged In**: The plugin will detect if local Antigravity is logged in. If valid credentials are detected, a prompt will ask whether to use the local account to log in directly
+2. **Logged In (using Local Token)**: If your account was imported via local Token, the plugin will periodically check for changes in local Antigravity login status:
+   - If the local account is switched, a prompt will ask whether to sync the new account
+   - If the local account logs out, a prompt will ask whether to sync the logout
 
 > [!TIP]
-> 本地 Token 检测路径：
+> Local Token detection paths:
 > - **Windows**: `%APPDATA%\Antigravity\User\globalStorage\state.vscdb`
 > - **macOS**: `~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb`
 > - **Linux**: `~/.config/Antigravity/User/globalStorage/state.vscdb`
 
 
-## PowerShell 模式（仅 Windows 系统可用）
-- **默认值**：`true`，如果false，则使用wmic检测进程
-- **说明**：使用 PowerShell 模式检测进程
-- **适用场景**：如果在 Windows 系统上遇到端口检测错误，可以尝试切换此选项。插件重启生效。
+## PowerShell Mode (Windows only)
+- **Default**: `true`, if false, uses wmic to detect processes
+- **Description**: Use PowerShell mode to detect processes
+- **Use Case**: If you encounter port detection errors on Windows, try toggling this option. Requires plugin restart to take effect.
 
-## 显示 Gemini 3 Pro (G Pro) 额度
-- **默认值**：`true`
-- **说明**：是否在状态栏显示 Gemini Pro 的额度信息
+## Show Gemini Pro (G Pro) Quota
+- **Default**: `true`
+- **Description**: Whether to display Gemini Pro quota in the status bar
 
-## 显示 Gemini 3 Flash (G Flash) 额度
-- **默认值**：`true`
-- **说明**：是否在状态栏显示 Gemini Flash 的额度信息
+## Show Gemini Flash (G Flash) Quota
+- **Default**: `true`
+- **Description**: Whether to display Gemini Flash quota in the status bar
 
-## 显示账号级别
-- **默认值**：`false`
-- **说明**：是否在状态栏显示账号级别（如 Free、Pro）
+## Show Account Tier
+- **Default**: `false`
+- **Description**: Whether to display account tier in the status bar (e.g., Free, Pro)
 
-## 语言设置
-- **默认值**：`zh-cn`
-- **选项**：
-  - `auto`：自动跟随 VS Code 语言设置
-  - `en`：英语
-  - `zh-cn`：简体中文
-- **说明**：设置状态栏语言，默认自动跟随 VS Code 语言
-> 如果要更改配置设置页面的显示语言，需要将antigravity的语言设置为中文
+## Language Settings
+- **Default**: `zh-cn`
+- **Options**:
+  - `auto`: Automatically follow VS Code language settings
+  - `en`: English
+  - `zh-cn`: Simplified Chinese
+- **Description**: Set status bar language, defaults to automatically follow VS Code language
+> To change the configuration settings page display language, you need to set Antigravity's language to Chinese

--- a/README.md
+++ b/README.md
@@ -1,128 +1,125 @@
 # <img src="./icon.png" width="80" style="vertical-align: middle"> Antigravity Quota Watcher
 
-#### Choose Your Language:  简体中文 | [English](./README.en.md)
-
 > [!WARNING]
-> **关于配额不刷新（一直显示100%）问题的公告**
+> **Notice: Quota Not Refreshing (Always Shows 100%)**
 >
-> 近期有用户反馈配额一直显示100%不刷新的问题，推测可能是官方接口机制变更导致。
+> Some users have reported that the quota always shows 100% and doesn't refresh. This is likely due to changes in the official API mechanism.
 >
-> **临时解决方案**：~~将代理节点设置为美国地区的节点~~,该方法目前似乎也已经失效，目前的配额递减规律是20%更新一次，100%->80%->60%...。
+> **Temporary Solution**: Set your proxy node to a US-based server.
 
-> [!NOTE]
-> 号外号外！本仓库为vscode插件版，[桌面版](https://github.com/wusimpl/AntigravityQuotaWatcherDesktop)已发布，欢迎下载体验
 
-**一个在Antigravity状态栏实时显示AI模型配额剩余情况的插件。**
+**A plugin that displays AI model quota status in real-time in the Antigravity status bar.**
 
-## 演示
+##  Demo
 
 <table>
   <tr>
     <td align="center">
-      <strong>状态栏显示</strong><br><br>
-      <img src="https://raw.githubusercontent.com/wusimpl/AntigravityQuotaWatcher/main/images/demo1.png" alt="状态栏显示" width="300">
+      <strong>Status Bar Display</strong><br><br>
+      <img src="https://raw.githubusercontent.com/wusimpl/AntigravityQuotaWatcher/main/images/demo1.png" alt="Status Bar Display" width="300">
     </td>
     <td align="center">
-      <strong>配额详情</strong><br><br>
-      <img src="https://raw.githubusercontent.com/wusimpl/AntigravityQuotaWatcher/main/images/demo2.png" alt="配额详情" width="400">
+      <strong>Quota Details</strong><br><br>
+      <img src="https://raw.githubusercontent.com/wusimpl/AntigravityQuotaWatcher/main/images/demo2-en.png" alt="Quota Details" width="400">
     </td>
     <td align="center">
-      <strong>配置页面<a href="./CONFIG.md">(配置文档)</a></strong><br><br>
-      <img src="https://raw.githubusercontent.com/wusimpl/AntigravityQuotaWatcher/main/images/demo3.png" alt="配置页面" width="400">
+      <strong>Config Page<a href="./CONFIG.md">(Config Doc)</a></strong><br><br>
+      <img src="https://raw.githubusercontent.com/wusimpl/AntigravityQuotaWatcher/main/images/demo3.png" alt="Config Page" width="400">
     </td>
   </tr>
 </table>
 
-## 系统要求
+## System Requirements
 
-![Windows](https://img.shields.io/badge/Windows--amd64-支持-brightgreen?logo=microsoftwindows&logoColor=white)
-![macOS](https://img.shields.io/badge/macOS-支持-brightgreen?logo=apple&logoColor=white)
-![Linux](https://img.shields.io/badge/Linux-支持-brightgreen?logo=linux&logoColor=white)
-![Windows ARM](https://img.shields.io/badge/Windows--arm64-不支持-red?logo=microsoftwindows&logoColor=white)
+![Windows](https://img.shields.io/badge/Windows--amd64-supported-brightgreen?logo=microsoftwindows&logoColor=white)
+![macOS](https://img.shields.io/badge/macOS-supported-brightgreen?logo=apple&logoColor=white)
+![Linux](https://img.shields.io/badge/Linux-supported-brightgreen?logo=linux&logoColor=white)
+![Windows ARM](https://img.shields.io/badge/Windows--arm64-not%20supported-red?logo=microsoftwindows&logoColor=white)
 
-## 安装方法
+## Installation
 
 
-### 方式一：插件市场安装（推荐）
+### Method 1: Install from Open VSX Marketplace (Recommended)
 
-在插件市场搜索 `wusimpl Antigravity Quota Watcher @sort:name`，认准作者为 `wusimpl` 的插件，点击安装即可。
+Search for `wusimpl Antigravity Quota Watcher @sort:name` in the extension marketplace. Look for the plugin by author `wusimpl` and then just click install.
 
 ![OpenVSX-Search PNG](./images/openvsx-search.png)
 
-### 方式二：手动安装
+### Method 2: Manual Installation
 
-[下载插件](https://github.com/wusimpl/AntigravityQuotaWatcher/releases/latest)，然后安装插件，重启 Antigravity
+[Download the extension](https://github.com/wusimpl/AntigravityQuotaWatcher/releases/latest), install it, and restart Antigravity.
 
 ![Installation](https://raw.githubusercontent.com/wusimpl/AntigravityQuotaWatcher/main/images/install.png)
 
-> [!NOTE]
-> Linux系统平台须知：请确保系统支持以下三种命令之一：`lsof`、`netstat`、`ss`。如果没有，请安装后再重启IDE。
 
-## 提交Issue
+> [!NOTE]
+> For Linux Distribution System, please make sure it supports one of these commands:`lsof`、`netstat`、`ss`.
+
+## Submitting Issues
 
 <details>
-<summary>点击展开</summary>
+<summary>Click to expand</summary>
 
-请在提交issue时附上日志文件或者日志截图
+Please attach log files or log screenshots when submitting issues.
 
-日志导出方法：
-![步骤页面1](https://raw.githubusercontent.com/wusimpl/AntigravityQuotaWatcher/main/images/issue1.png)
-![步骤页面2](https://raw.githubusercontent.com/wusimpl/AntigravityQuotaWatcher/main/images/issue2.png)
+How to export logs:
+![Step 1](https://raw.githubusercontent.com/wusimpl/AntigravityQuotaWatcher/main/images/issue1.png)
+![Step 2](https://raw.githubusercontent.com/wusimpl/AntigravityQuotaWatcher/main/images/issue2.png)
 
 </details>
 
 
-##  功能特点
+## Features
 
-- **实时监控**：自动检测并定时轮询配额使用情况
-- **状态栏显示**：在 VS Code 底部状态栏显示当前配额
-- **智能预警**：配额不足时自动变色提醒
-- **自动检测**：无需手动配置，自动检测 Antigravity 服务端口和认证信息
-- **本地登录同步**：自动检测 Antigravity IDE 的登录状态，支持一键导入本地账号凭证
-- **Dashboard 面板**：提供配额概览、连接状态、周限检测等功能
+- **Real-time Monitoring**: Automatically detects and polls quota usage at regular intervals
+- **Status Bar Display**: Shows current quota in the VS Code bottom status bar
+- **Smart Alerts**: Automatically changes color when quota is low
+- **Auto Detection**: No manual configuration needed, automatically detects Antigravity service port and authentication information
+- **Local Login Sync**: Automatically detects Antigravity IDE login status and supports one-click import of local account credentials
+- **Dashboard Panel**: Provides quota overview, connection status, weekly limit detection and more
 
 ## Dashboard
 
-通过命令面板执行 `Antigravity Quota Watcher: Open Dashboard` 可打开 Dashboard 面板，提供以下功能：
+Open the Dashboard panel via command palette `Antigravity Quota Watcher: Open Dashboard`, which provides:
 
-- **配额概览**：以表格形式展示所有模型的剩余配额和重置时间
-- **连接状态**：显示当前 API 模式、端口信息、轮询状态等
-- **账号信息**：显示当前登录账号和订阅计划
-- **快捷操作**：刷新配额、重新检测端口、登录/登出等
+- **Quota Overview**: Displays all model quotas and reset times in a table
+- **Connection Status**: Shows current API mode, port info, polling status, etc.
+- **Account Info**: Displays current logged-in account and subscription plan
+- **Quick Actions**: Refresh quota, re-detect port, login/logout, etc.
 
 <img src="https://raw.githubusercontent.com/wusimpl/AntigravityQuotaWatcher/main/images/dashboard.jpg" alt="Dashboard" width="500">
 
 <details>
-<summary><b>周限检测</b>（点击展开）</summary>
+<summary><b>Weekly Limit Detection</b> (click to expand)</summary>
 
-在 Dashboard 面板中，可以对每个模型池进行周限检测，判断是否触发了周配额限制。
+In the Dashboard panel, you can check each model pool for weekly quota limits.
 
-> ⚠️ 周限检测会发送一次测试请求，会消耗少量配额。
+> ⚠️ Weekly limit detection sends a test request, which consumes a small amount of quota.
 
-**配额池划分：**
-- Gemini 3.x 池
-- Claude / GPT 池
-- Gemini 2.5 池
+**Quota Pools:**
+- Gemini 3.x Pool
+- Claude / GPT Pool
+- Gemini 2.5 Pool
 
-**判断逻辑：**
+**Detection Logic:**
 
 ```
-                    发送测试请求（提示词为"Hi"）
+                    Send test request (prompt: "Hi")
                                 │
                                 ▼
-                        HTTP 状态码？
+                        HTTP Status Code?
                                 │
             ┌───────────────────┼───────────────────┐
             │                   │                   │
             ▼                   ▼                   ▼
-           200                 429                其他
+           200                 429                Other
             │                   │                   │
             ▼                   ▼                   ▼
-        ✅ 配额            解析 error            ❓ 未知
-           正常              .details              错误
+        ✅ Quota           Parse error          ❓ Unknown
+            OK               .details              error
                                 │
                                 ▼
-                           reason 是？
+                            reason?
                                 │
             ┌───────────────────┼───────────────────┐
             │                   │                   │
@@ -131,124 +128,125 @@
             │              EXCEEDED           EXHAUSTED
             │                   │                   │
             ▼                   ▼                   ▼
-       重置时间多久？       ⚠️ 请求太频繁      ⚠️ 服务器过载
-            │                                  请稍后重试
+        Reset time?        ⚠️ Too many        ⚠️ Server overloaded
+            │                requests           Try again later
        ┌────┴────┐
        │         │
        ▼         ▼
       >5h       ≤5h
        │         │
        ▼         ▼
-    ❌ 周限   ⚠️ 5h限速
+   ❌ Weekly  ⚠️ 5h rate
+      limit      limit
 ```
 
 </details>
 
-##  配置选项
+## Configuration Options
 
-详细配置说明请查看：**[📖 配置文档](./CONFIG.md)**
-
-
-### 命令面板
-命令面板支持手动调用一些命令，这些命令用于排错和调用不常用的功能。
-按 `Ctrl+Shift+P`（Windows）或 `Cmd+Shift+P`（Mac）打开命令面板，支持以下命令：
-
-**通用命令：**
-- **Antigravity Quota Watcher: Refresh Quota** - 手动刷新配额数据
-- **Antigravity Quota Watcher: Open Dashboard** - 打开 Dashboard 面板
-
-**仅适用于 GET_USER_STATUS 方式的命令：**
-- **Antigravity Quota Watcher: Re-detect Port** - 重新检测 Antigravity 服务端口
-
-**仅适用于 GOOGLE_API 方式的命令：**
-- **Antigravity Quota Watcher: Login with Google** - 使用 Google 账号登录
-- **Antigravity Quota Watcher: Logout from Google** - 登出 Google 账号
+For detailed configuration instructions, please see: **[📖 Configuration Documentation](./CONFIG.en.md)**
 
 
-## 状态栏说明
+### Command Palette
+The command palette allows you to manually invoke commands for troubleshooting and accessing less frequently used features.
+Press `Ctrl+Shift+P` (Windows) or `Cmd+Shift+P` (Mac) to open the command palette. The following commands are available:
+
+**General Commands:**
+- **Antigravity Quota Watcher: Refresh Quota** - Manually refresh quota data
+- **Antigravity Quota Watcher: Open Dashboard** - Open the Dashboard panel
+
+**Commands only for GET_USER_STATUS method:**
+- **Antigravity Quota Watcher: Re-detect Port** - Re-detect Antigravity service port
+
+**Commands only for GOOGLE_API method:**
+- **Antigravity Quota Watcher: Login with Google** - Login with Google account
+- **Antigravity Quota Watcher: Logout from Google** - Logout from Google account
+
+
+## Status Bar Explanation
 
 <details>
-<summary>点击展开</summary>
+<summary>Click to expand</summary>
 
-状态栏显示格式：
+Status bar display format:
 
-### 1. 进度条模式
-显示格式：`🟢 Pro-L ████████ | 🔴 Claude ██░░░░░░`
-直观展示剩余配额的比例。
+### 1. Progress Bar Mode
+Display format: `🟢 Pro-L ████████ | 🔴 Claude ██░░░░░░`
+Visually shows the proportion of remaining quota.
 
-### 2. 百分比模式（默认）
-显示格式：`🟢 Pro-L: 80% | 🔴 Claude: 25%`
-直接显示剩余配额的百分比数值。
+### 2. Percentage Mode (Default)
+Display format: `🟢 Pro-L: 80% | 🔴 Claude: 25%`
+Directly displays the percentage value of remaining quota.
 
-### 3. 圆点模式
-显示格式：`🟢 Pro-L ●●●●○ | 🔴 Claude ●●○○○`
-使用圆点直观表示剩余配额比例，更加简洁美观。
+### 3. Dots Mode
+Display format: `🟢 Pro-L ●●●●○ | 🔴 Claude ●●○○○`
+Uses dots to visually represent remaining quota proportion, more concise and elegant.
 
-### 状态指示符号
+### Status Indicator Symbols
 
-每个模型前的圆点符号表示当前配额状态：
+The dot symbol before each model indicates the current quota status:
 
-- **🟢 绿色**：剩余配额 ≥ 50%（充足）
-- **🟡 黄色**：剩余配额 30%-50%（中等）
-- **🔴 红色**：剩余配额 < 30%（不足）
-- **⚫ 黑色**：配额已耗尽（0%）
+- **🟢 Green**: Remaining quota ≥ 50% (sufficient)
+- **🟡 Yellow**: Remaining quota 30%-50% (moderate)
+- **🔴 Red**: Remaining quota < 30% (insufficient)
+- **⚫ Black**: Quota exhausted (0%)
 
-您可以在设置中自定义 `warningThreshold`（警告阈值）和 `criticalThreshold`（临界阈值）来调整状态符号的显示级别。
+You can customize `warningThreshold` and `criticalThreshold` in settings to adjust the display level of status symbols.
 
-### 模型配额详情
+### Model Quota Details
 
-鼠标移动到状态栏会显示所有模型的剩余配额与下次重置时间。**点击状态栏可以立即刷新配额信息**。
+Hover over the status bar to see remaining quota and next reset time for all models. **Click the status bar to immediately refresh quota information**.
 
 </details>
 
-## 代理设置
+## Proxy Settings
 
 <details>
-<summary>点击展开</summary>
+<summary>Click to expand</summary>
 
-适用于未开启tun模式，使用proxifer对antigravity代理的类似用户。
-首先需要明确的是，antigravity内置代理支持功能，可通过 `http.proxySupport` 设置控制：
+Suitable for users who have not enabled TUN mode and use tools like Proxifier to proxy antigravity.
+First, it should be clarified that antigravity has built-in proxy support, which can be controlled via the `http.proxySupport` setting:
 
-| 设置值 | 说明 |
-|--------|------|
-| `override`| **自动使用操作系统的代理设置**。如果你已经在代理软件中设置了系统代理，antigravity 会自动检测并使用，无需额外配置。 |
-| `on` | 使用 `http.proxy` 中手动配置的代理 |
-| `fallback` | 先尝试直连，失败后使用代理 |
-| `off` | 完全不使用代理 |
+| Value | Description |
+|-------|-------------|
+| `override`| **Automatically use operating system proxy settings**. If you have already set up a system proxy in your proxy software, antigravity will automatically detect and use it without additional configuration. |
+| `on`| Use the proxy manually configured in `http.proxy` |
+| `fallback`| Try direct connection first, then use proxy if it fails |
+| `off`| Do not use proxy at all |
 
-**插件会自动继承 antigravity 的代理设置**。如果你的 antigravity 已经能正常通过代理访问网络，本插件也会自动使用相同的代理，无需额外配置。
+**The plugin will automatically inherit antigravity's proxy settings**. If your antigravity is already able to access the network through a proxy normally, this plugin will also automatically use the same proxy without additional configuration.
 
-特殊情况下，如果需要为本插件单独配置代理，可以使用插件单独的代理配置功能：
-**使用环境变量代理**：启用 `proxyEnabled` 和 `proxyAutoDetect`，插件会自动读取 `HTTPS_PROXY` 或 `HTTP_PROXY` 环境变量
-或者
-**手动指定代理**：启用 `proxyEnabled`，然后填写 `proxyUrl`
+In special cases, if you need to configure a proxy specifically for this plugin, you can use the plugin's independent proxy configuration feature:
+**Use environment variable proxy**: Enable `proxyEnabled` and `proxyAutoDetect`, the plugin will automatically read `HTTPS_PROXY` or `HTTP_PROXY` environment variables.
+OR
+**Manually specify proxy**: Enable `proxyEnabled`, then fill in `proxyUrl`.
 
 </details>
 
-## 注意事项
+## Notes
 
-- 首次启动会延迟 8 秒开始监控，避免频繁请求
-- 如果状态栏显示错误，可使用"重新检测端口"命令修复
-- **Windows 用户**：如果遇到端口检测错误，可以在设置中切换 `forcePowerShell` 选项。
-- 本插件为非官方工具，与 Antigravity 没有任何关联。本插件部分依赖于 Antigravity 语言服务器的内部实现细节，相关机制可能会随时变动。
-- 本插件从V0.9.0版本开始支持 VS Code fork IDE（WindSurf, Kiro, VS Code 等）。如需使用，请在配置中切换到**GOOGLE_API**方式获取模型配额，该方法不依赖于 Antigravity 本地环境，远程SSH项目也适合这种方法。
+- First startup will delay 8 seconds before starting monitoring to avoid frequent requests
+- If the status bar shows an error, use the "Re-detect Port" command to fix it
+- **Windows Users**: If you encounter port detection errors, you can toggle the `forcePowerShell` option in settings.
+- This plugin is an unofficial tool and has no affiliation with Antigravity. This plugin relies on internal implementation details of the Antigravity language server, which may change at any time.
+- This plugin supports VS Code fork IDEs (WindSurf, Kiro, VS Code, etc.) from V0.9.0. To watch model quotas in fork IDEs, switch to the **GOOGLE_API** method in settings. This method does not depend on the Antigravity local environment, making it also suitable for remote SSH projects.
 
-## 致谢
- * Google API 配额获取方法来自 [Antigravity-Manager](https://github.com/lbjlaq/Antigravity-Manager) 项目，感谢作者的贡献！
- * 参考了 [anti-quota](https://github.com/fhyfhy17/anti-quota) 获取 Antigravity 本地登录账号Token的方法，感谢作者的贡献！
- * 周限检测功能参考了 [gcli2api](https://github.com/su-kaka/gcli2api) 项目的 2api 方法，感谢作者的贡献！
+## Acknowledgments
+ * The Google API quota retrieval method comes from the [Antigravity-Manager](https://github.com/lbjlaq/Antigravity-Manager) project. Thanks to the author for the contribution!
+ * Referenced the method for obtaining Antigravity local login account Token from [anti-quota](https://github.com/fhyfhy17/anti-quota). Thanks to the author for the contribution!
+ * The weekly limit detection feature references the 2api method from [gcli2api](https://github.com/su-kaka/gcli2api). Thanks to the author for the contribution!
 
-[![Star History Chart](https://api.star-history.com/svg?repos=wusimpl/AntigravityQuotaWatcher&type=date&legend=top-left)](https://www.star-history.com/#wusimpl/AntigravityQuotaWatcher&type=date&legend=top-left)
+[![Star History Chart](https://api.star-history.com/svg?repos=wusimpl/AntigravityQuotaWatcher&type=Date)](https://star-history.com/#wusimpl/AntigravityQuotaWatcher&Date)
 
-## 项目使用约定
+## Usage Agreement
 
-本项目基于 MIT 协议开源，使用此项目时请遵守开源协议。  
-除此外，希望你在使用代码时已经了解以下额外说明：
+This project is open-sourced under the MIT License. Please comply with the open-source license when using this project.  
+In addition, we hope you are aware of the following additional notes when using the code:
 
-1. 打包、二次分发 **请保留代码出处**：[https://github.com/wusimpl/AntigravityQuotaWatcher](https://github.com/wusimpl/AntigravityQuotaWatcher)
-2. 请不要用于商业用途，合法合规使用代码
-3. 如果开源协议变更，将在此 Github 仓库更新，不另行通知。
+1. When packaging or redistributing, **please retain the source attribution**: [https://github.com/wusimpl/AntigravityQuotaWatcher](https://github.com/wusimpl/AntigravityQuotaWatcher)
+2. Please do not use for commercial purposes. Use the code legally and compliantly.
+3. If the open-source license changes, it will be updated in this GitHub repository without separate notice.
 
-## 许可证
+## License
 
 MIT License

--- a/package.nls.json
+++ b/package.nls.json
@@ -18,7 +18,7 @@
     "config.showGeminiFlash": "Show Gemini Flash (G Flash) quota in status bar",
     "config.showPromptCredits": "Show Prompt Credits (not officially enabled yet)",
     "config.forcePowerShell": "Use PowerShell mode for process detection [Windows only, requires extension restart]",
-    "config.language": "Language / 语言",
+    "config.language": "Language",
     "config.logLevel": "Log level for debugging",
     "config.proxyEnabled": "Enable proxy for network requests",
     "config.proxyAutoDetect": "Auto-detect system proxy (HTTPS_PROXY, HTTP_PROXY environment variables)",


### PR DESCRIPTION
Translates README.md and CONFIG.md to English as requested in #48.

Changes:
- README.md → full English translation
- CONFIG.md → full English translation  
- package.nls.json → matched all keys from zh-cn version
- Chinese reference files preserved (README.en.md, CONFIG.en.md unchanged)

No functionality, versioning, or dependencies touched.