### PR TITLE
fix: select latest Gemini quota models

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,11 +23,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Lint
-        run: npm run lint
-
-      - name: Compile
-        run: npm run compile
+      - name: Test
+        run: npm test
 
       - name: Package Extension
         run: npx vsce package

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -5,6 +5,7 @@ src/**
 # 开发工具配置
 .vscode/**
 .vscode-test/**
+out/test/**
 .gitignore
 .yarnrc
 .eslintrc.json

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
-    "test": "node ./out/test/runTest.js",
+    "test": "node --test out/test/modelSelection.test.js",
     "package": "npx vsce package"
   },
   "devDependencies": {

--- a/src/api/googleCloudCodeClient.ts
+++ b/src/api/googleCloudCodeClient.ts
@@ -14,6 +14,7 @@ import {
 } from '../auth/constants';
 import { logger } from '../logger';
 import { ProxyService } from '../proxyService';
+import { shouldIncludeGeminiModel } from '../geminiModelSelection';
 
 /**
  * 项目信息 (loadCodeAssist 响应)
@@ -163,19 +164,23 @@ export class GoogleCloudCodeClient {
         const allowedModelPatterns = /gemini|claude|gpt/i;
 
         for (const [modelName, modelInfo] of Object.entries(modelsMap)) {
+            const info = modelInfo as any;
+            const apiDisplayName = typeof info.displayName === 'string'
+                ? info.displayName.trim()
+                : '';
+
             // 过滤模型名称
-            if (!allowedModelPatterns.test(modelName)) {
+            if (![modelName, apiDisplayName].some(name => allowedModelPatterns.test(name))) {
                 filteredByName.push(modelName);
                 continue;
             }
 
-            // 过滤旧版本 Gemini 模型 (< 3.0)
-            if (!this.isModelVersionSupported(modelName)) {
+            // 仅过滤可识别的旧版本 Gemini；未知命名留给显示层安全回退
+            if (!this.isModelVersionSupported(modelName, apiDisplayName)) {
                 filteredByVersion.push(modelName);
                 continue;
             }
 
-            const info = modelInfo as any;
             if (info.quotaInfo) {
                 // [DEBUG] 打印关键的模型配额信息
                 logger.info('GoogleAPI', `[QUOTA_DEBUG] Model "${modelName}": remaining=${info.quotaInfo.remainingFraction}, resetTime=${info.quotaInfo.resetTime}, maxTokens=${info.maxTokens || 'N/A'}`);
@@ -209,7 +214,10 @@ export class GoogleCloudCodeClient {
         const remainingFraction = quotaInfo.remainingFraction ?? 0;
 
         // 生成友好的显示名称
-        const displayName = this.formatModelDisplayName(modelName);
+        const apiDisplayName = typeof modelInfo.displayName === 'string'
+            ? modelInfo.displayName.trim()
+            : '';
+        const displayName = apiDisplayName || this.formatModelDisplayName(modelName);
 
         return {
             modelName: modelName,
@@ -406,28 +414,16 @@ export class GoogleCloudCodeClient {
     }
 
     /**
-     * 检查模型版本是否支持 (过滤掉 3.0 以下的 Gemini)
+     * 过滤可识别的 3.0 以下 Gemini，保留未知命名以便显示层回退
      */
-    private isModelVersionSupported(modelName: string): boolean {
-        const lowerName = modelName.toLowerCase();
+    private isModelVersionSupported(modelName: string, displayName: string): boolean {
+        const names = [modelName, displayName];
 
         // 如果不是 Gemini 模型，直接支持 (如 Claude, GPT)
-        if (!lowerName.includes('gemini')) {
+        if (!names.some(name => name.toLowerCase().includes('gemini'))) {
             return true;
         }
 
-        // 提取版本号 (例如 gemini-2.5-flash -> 2.5)
-        // 匹配 patterns: gemini-1.5, gemini-2.0, gemini-1.0-pro
-        const versionMatch = lowerName.match(/gemini-(\d+(?:\.\d+)?)/);
-
-        if (versionMatch && versionMatch[1]) {
-            const version = parseFloat(versionMatch[1]);
-            // 只允许版本 >= 3.0
-            return version >= 3.0;
-        }
-
-        // 如果没有匹配到版本号的 Gemini (例如 gemini-pro, 通常指 1.0)，默认过滤掉
-        // 为了安全起见，如果不带版本号，假设是旧版本
-        return false;
+        return shouldIncludeGeminiModel({ modelId: modelName, label: displayName || modelName });
     }
 }

--- a/src/api/weeklyLimitChecker.ts
+++ b/src/api/weeklyLimitChecker.ts
@@ -93,7 +93,7 @@ export function getQuotaPool(modelName: string): QuotaPool {
 export function getPoolRepresentativeModel(pool: QuotaPool): string {
     switch (pool) {
         case 'gemini3':
-            return 'gemini-3.0-flash';  // Gemini 3.x 池子
+            return 'gemini-3-flash-agent';
         case 'claude_gpt':
             return 'claude-3-5-sonnet';
         case 'gemini2.5':

--- a/src/geminiModelSelection.ts
+++ b/src/geminiModelSelection.ts
@@ -1,0 +1,122 @@
+export interface GeminiModelCandidate {
+  label: string;
+  modelId?: string;
+}
+
+export type GeminiVersion = readonly number[];
+
+const MIN_COMPATIBLE_GEMINI_VERSION: GeminiVersion = [3, 0];
+const GEMINI_VERSION_PATTERN = /\bgemini[\s_-]+v?(\d+(?:[._-]\d+)*)(?![._-][._\d-])(?=$|[\s_(/-])/i;
+
+export function parseGeminiVersion(name: string): GeminiVersion | undefined {
+  const match = name.match(GEMINI_VERSION_PATTERN);
+  if (!match) {
+    return undefined;
+  }
+
+  const components = match[1].split(/[._-]/).map(Number);
+  return components.every(Number.isSafeInteger) ? components : undefined;
+}
+
+export function compareGeminiVersions(a: GeminiVersion, b: GeminiVersion): number {
+  const componentCount = Math.max(a.length, b.length);
+  for (let index = 0; index < componentCount; index++) {
+    const difference = (a[index] ?? 0) - (b[index] ?? 0);
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+  return 0;
+}
+
+export function isCompatibleGeminiVersion(version: GeminiVersion): boolean {
+  return compareGeminiVersions(version, MIN_COMPATIBLE_GEMINI_VERSION) >= 0;
+}
+
+function getGeminiVersion(model: GeminiModelCandidate): GeminiVersion | undefined {
+  let bestVersion: GeminiVersion | undefined;
+  for (const name of [model.modelId, model.label]) {
+    if (!name) {
+      continue;
+    }
+    const version = parseGeminiVersion(name);
+    if (version && (!bestVersion || compareGeminiVersions(version, bestVersion) > 0)) {
+      bestVersion = version;
+    }
+  }
+  return bestVersion;
+}
+
+export function shouldIncludeGeminiModel(model: GeminiModelCandidate): boolean {
+  const version = getGeminiVersion(model);
+  return version === undefined || isCompatibleGeminiVersion(version);
+}
+
+function matchesName(model: GeminiModelCandidate, parts: readonly string[]): boolean {
+  return [model.label, model.modelId].some(name => {
+    const lowerName = name?.toLowerCase();
+    return lowerName !== undefined && parts.every(part => lowerName.includes(part));
+  });
+}
+
+function selectLatestCompatible<T extends GeminiModelCandidate>(
+  models: readonly T[],
+  matches: (model: T) => boolean,
+  getTierPriority: (model: T) => number = () => 0
+): T | undefined {
+  let latest: T | undefined;
+  let latestVersion: GeminiVersion | undefined;
+  let latestTierPriority = 0;
+  let unknownVersionFallback: T | undefined;
+
+  for (const model of models) {
+    if (!matches(model)) {
+      continue;
+    }
+
+    const version = getGeminiVersion(model);
+    if (!version) {
+      // Preserve API order for the fallback when no candidate has a usable version.
+      unknownVersionFallback ??= model;
+      continue;
+    }
+    if (!isCompatibleGeminiVersion(version)) {
+      continue;
+    }
+
+    const versionComparison = latestVersion
+      ? compareGeminiVersions(version, latestVersion)
+      : 1;
+    const tierPriority = getTierPriority(model);
+    // Equal version and tier intentionally keep the first candidate in API order.
+    if (versionComparison > 0 || (versionComparison === 0 && tierPriority > latestTierPriority)) {
+      latest = model;
+      latestVersion = version;
+      latestTierPriority = tierPriority;
+    }
+  }
+
+  return latest ?? unknownVersionFallback;
+}
+
+export function selectLatestGeminiFlash<T extends GeminiModelCandidate>(models: readonly T[]): T | undefined {
+  return selectLatestCompatible(
+    models,
+    model => matchesName(model, ['gemini', 'flash']),
+    model => {
+      if (matchesName(model, ['high'])) {
+        return 3;
+      }
+      if (matchesName(model, ['medium'])) {
+        return 2;
+      }
+      return matchesName(model, ['low']) ? 1 : 0;
+    }
+  );
+}
+
+export function selectLatestGeminiProLow<T extends GeminiModelCandidate>(models: readonly T[]): T | undefined {
+  return selectLatestCompatible(models, model =>
+    matchesName(model, ['gemini', 'pro', 'low'])
+  );
+}

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -5,6 +5,7 @@
 import * as vscode from 'vscode';
 import { ModelQuotaInfo, QuotaSnapshot } from './types';
 import { LocalizationService } from './i18n/localizationService';
+import { selectLatestGeminiFlash, selectLatestGeminiProLow } from './geminiModelSelection';
 
 export class StatusBarService {
   private statusBarItem: vscode.StatusBarItem;
@@ -240,7 +241,7 @@ export class StatusBarService {
 
     // 2. Gemini Pro (Low) - 根据配置决定是否显示
     if (this.showGeminiPro) {
-      const proLow = models.find(model => this.isProLow(model.label));
+      const proLow = selectLatestGeminiProLow(models);
       if (proLow && !result.includes(proLow)) {
         result.push(proLow);
       }
@@ -248,23 +249,13 @@ export class StatusBarService {
 
     // 3. Gemini Flash - 根据配置决定是否显示
     if (this.showGeminiFlash) {
-      const flash = models.find(model => this.isGemini3Flash(model.label));
+      const flash = selectLatestGeminiFlash(models);
       if (flash && !result.includes(flash)) {
         result.push(flash);
       }
     }
 
     return result;
-  }
-
-  private isProLow(label: string): boolean {
-    const lower = label.toLowerCase();
-    return lower.includes('pro') && lower.includes('low');
-  }
-
-  private isGemini3Flash(label: string): boolean {
-    const lower = label.toLowerCase();
-    return lower.includes('gemini') && lower.includes('flash');
   }
 
   private isClaudeWithoutThinking(label: string): boolean {

--- a/src/test/modelSelection.test.ts
+++ b/src/test/modelSelection.test.ts
@@ -1,0 +1,199 @@
+import { strict as assert } from 'node:assert';
+import Module = require('node:module');
+import { test } from 'node:test';
+import {
+  compareGeminiVersions,
+  parseGeminiVersion,
+  selectLatestGeminiFlash,
+  selectLatestGeminiProLow,
+  shouldIncludeGeminiModel,
+} from '../geminiModelSelection';
+
+interface ModelFixture {
+  label: string;
+  modelId: string;
+}
+
+type GoogleCloudCodeClientModule = typeof import('../api/googleCloudCodeClient');
+
+interface CommonJsModuleLoader {
+  _load(request: string, parent: unknown, isMain: boolean): unknown;
+}
+
+function model(label: string, modelId: string): ModelFixture {
+  return { label, modelId };
+}
+
+const flash35High = model('Gemini 3.5 Flash (High)', 'gemini-3-flash-agent');
+const flash35Medium = model('Gemini 3.5 Flash (Medium)', 'gemini-3.5-flash-low');
+const flash35Low = model('Gemini 3.5 Flash (Low)', 'gemini-3.5-flash-extra-low');
+
+function loadGoogleCloudCodeClient(): GoogleCloudCodeClientModule {
+  const loader = Module as unknown as CommonJsModuleLoader;
+  const originalLoad = loader._load;
+
+  loader._load = (request, parent, isMain) => {
+    if (request === 'vscode') {
+      return {
+        workspace: {
+          getConfiguration: () => ({
+            get: (_key: string, fallback: unknown) => fallback === 'DEBUG' ? 'ERROR' : fallback,
+          }),
+        },
+      };
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  try {
+    return Module.createRequire(__filename)('../api/googleCloudCodeClient') as GoogleCloudCodeClientModule;
+  } finally {
+    loader._load = originalLoad;
+  }
+}
+
+const { GoogleCloudCodeClient } = loadGoogleCloudCodeClient();
+
+test('parses and compares numeric Gemini versions', () => {
+  assert.deepEqual(parseGeminiVersion('gemini-3.0-flash'), [3, 0]);
+  assert.deepEqual(parseGeminiVersion('Gemini 3.1 Pro (Low)'), [3, 1]);
+  assert.deepEqual(parseGeminiVersion('gemini-3-5-flash-high'), [3, 5]);
+  assert.equal(parseGeminiVersion('Gemini 3..5 Flash'), undefined);
+  assert.equal(parseGeminiVersion('Gemini next Flash'), undefined);
+
+  const versionThreeTen = parseGeminiVersion('gemini-3.10-flash');
+  const versionThreeFive = parseGeminiVersion('gemini-3.5-flash');
+  assert.ok(versionThreeTen);
+  assert.ok(versionThreeFive);
+  assert.ok(compareGeminiVersions(versionThreeTen, versionThreeFive) > 0);
+});
+
+test('uses the best version from the alias and display label', () => {
+  const flash30 = model('Gemini 3.0 Flash (High)', 'gemini-3-flash-preview');
+  const flash31 = model('Gemini 3.1 Flash (High)', 'gemini-3.1-flash-preview');
+  const unknown = model('Gemini Flash Experimental (High)', 'gemini-flash-experimental');
+
+  assert.equal(selectLatestGeminiFlash([flash31, unknown, flash30, flash35High]), flash35High);
+  assert.equal(selectLatestGeminiFlash([flash35High, flash30, flash31, unknown]), flash35High);
+});
+
+test('selects only the newest Pro Low model', () => {
+  const proLow30 = model('Gemini 3.0 Pro (Low)', 'gemini-3-pro-preview');
+  const proLow31 = model('Gemini 3.1 Pro (Low)', 'gemini-3-pro-preview');
+  const proHigh35 = model('Gemini 3.5 Pro (High)', 'gemini-3-pro-preview');
+
+  assert.equal(selectLatestGeminiProLow([proLow30, proHigh35, proLow31]), proLow31);
+  assert.equal(selectLatestGeminiProLow([proLow31, proLow30, proHigh35]), proLow31);
+});
+
+test('prefers the observed High, Medium, and Low aliases in tier order', () => {
+  const flash35Untiered = model('Gemini 3.5 Flash', 'gemini-3-flash-agent');
+  const flash31 = model('Gemini 3.1 Flash (High)', 'gemini-3.1-flash-preview');
+
+  assert.equal(selectLatestGeminiFlash([flash35Low, flash35Medium, flash35High, flash31]), flash35High);
+  assert.equal(selectLatestGeminiFlash([flash35High, flash35Medium, flash35Low, flash31]), flash35High);
+  assert.equal(selectLatestGeminiFlash([flash35Low, flash35Medium]), flash35Medium);
+  assert.equal(selectLatestGeminiFlash([flash35Low]), flash35Low);
+  assert.equal(selectLatestGeminiFlash([flash35Untiered, flash35Medium]), flash35Medium);
+});
+
+test('keeps first-seen candidates for exact ties and unknown-version fallback', () => {
+  const duplicateHigh = model(flash35High.label, flash35High.modelId);
+  const malformedFlash = model('Gemini 3..5 Flash (Medium)', 'gemini-3..5-flash-agent');
+  const unknownFlash = model('Gemini Flash Experimental (High)', 'gemini-flash-experimental');
+  const unknownProLow = model('Gemini Pro (Low)', 'gemini-pro-low');
+  const legacyFlash = model('Gemini 2.5 Flash', 'gemini-2.5-flash');
+
+  assert.equal(selectLatestGeminiFlash([flash35High, duplicateHigh]), flash35High);
+  assert.equal(selectLatestGeminiFlash([duplicateHigh, flash35High]), duplicateHigh);
+  assert.equal(selectLatestGeminiFlash([malformedFlash, unknownFlash]), malformedFlash);
+  assert.equal(selectLatestGeminiFlash([unknownFlash, malformedFlash]), unknownFlash);
+  assert.equal(selectLatestGeminiProLow([unknownProLow]), unknownProLow);
+  assert.equal(selectLatestGeminiFlash([legacyFlash]), undefined);
+});
+
+test('extracts observed Google API models before selecting the Flash tier', async () => {
+  const responseFixture = {
+    models: {
+      'gemini-3.5-flash-extra-low': {
+        displayName: 'Gemini 3.5 Flash (Low)',
+        quotaInfo: {
+          remainingFraction: 0.25,
+          resetTime: '2026-07-14T01:00:00.000Z',
+        },
+      },
+      'gemini-3.5-flash-low': {
+        displayName: 'Gemini 3.5 Flash (Medium)',
+        quotaInfo: {
+          remainingFraction: 0.5,
+          resetTime: '2026-07-14T02:00:00.000Z',
+        },
+      },
+      'gemini-3-flash-agent': {
+        displayName: 'Gemini 3.5 Flash (High)',
+        quotaInfo: {
+          remainingFraction: 0.75,
+          resetTime: '2026-07-14T03:00:00.000Z',
+        },
+      },
+    },
+  };
+  const client = GoogleCloudCodeClient.getInstance();
+  const requestTarget = client as unknown as {
+    makeApiRequest(path: string, accessToken: string, body: object): Promise<unknown>;
+  };
+  const originalRequest = requestTarget.makeApiRequest;
+  requestTarget.makeApiRequest = async () => responseFixture;
+
+  try {
+    const response = await client.fetchModelsQuota('fixture-token', 'fixture-project');
+    assert.deepEqual(
+      response.models.map(({ modelName, displayName, remainingQuota }) => ({
+        modelName,
+        displayName,
+        remainingQuota,
+      })),
+      [
+        {
+          modelName: 'gemini-3.5-flash-extra-low',
+          displayName: 'Gemini 3.5 Flash (Low)',
+          remainingQuota: 0.25,
+        },
+        {
+          modelName: 'gemini-3.5-flash-low',
+          displayName: 'Gemini 3.5 Flash (Medium)',
+          remainingQuota: 0.5,
+        },
+        {
+          modelName: 'gemini-3-flash-agent',
+          displayName: 'Gemini 3.5 Flash (High)',
+          remainingQuota: 0.75,
+        },
+      ]
+    );
+
+    const extractedCandidates = response.models.map(extracted => model(
+      extracted.displayName,
+      extracted.modelName
+    ));
+    assert.equal(selectLatestGeminiFlash(extractedCandidates)?.modelId, 'gemini-3-flash-agent');
+    assert.equal(
+      selectLatestGeminiFlash(extractedCandidates.filter(candidate => candidate.modelId !== 'gemini-3-flash-agent'))?.modelId,
+      'gemini-3.5-flash-low'
+    );
+    assert.equal(
+      selectLatestGeminiFlash(extractedCandidates.filter(candidate => candidate.modelId.endsWith('extra-low')))?.modelId,
+      'gemini-3.5-flash-extra-low'
+    );
+  } finally {
+    requestTarget.makeApiRequest = originalRequest;
+  }
+});
+
+test('keeps unknown Gemini aliases eligible for Google API fallback', () => {
+  assert.equal(shouldIncludeGeminiModel(flash35High), true);
+  assert.equal(shouldIncludeGeminiModel(model('Gemini Flash Experimental', 'MODEL_PLACEHOLDER_M47')), true);
+  assert.equal(shouldIncludeGeminiModel(model('Gemini 3..5 Flash', 'gemini-3..5-flash-agent')), true);
+  assert.equal(shouldIncludeGeminiModel(model('Gemini 3.5 Flash', 'gemini-2.5-flash')), true);
+  assert.equal(shouldIncludeGeminiModel(model('Gemini 2.5 Flash', 'gemini-2.5-flash')), false);
+});


### PR DESCRIPTION
## Summary
- Preserve API display names and select the newest compatible Gemini Pro Low and Flash models by version and tier.
- Keep unknown aliases as fallbacks while excluding recognizable pre-3.0 models.
- Update the Gemini 3 weekly-limit probe alias and run focused tests in the build workflow.

Closes #49

## Testing
- npm test (compile, ESLint, and 7 tests; one pre-existing ESLint warning)
- git diff --check

## Risks
- No live provider testing was performed; future or ambiguous model names may use the API-order fallback.